### PR TITLE
Sanitize folder name correctly on creation

### DIFF
--- a/lib/sharepoint/client.rb
+++ b/lib/sharepoint/client.rb
@@ -297,6 +297,7 @@ module Sharepoint
     #
     # @return [Fixnum] HTTP response code
     def create_folder(name, path, site_path=nil)
+      return unless name
       sanitized_name = sanitize_filename(name)
       url = computed_web_api_url(site_path)
       path = path[1..-1] if path[0].eql?('/')
@@ -309,7 +310,7 @@ module Sharepoint
           '__metadata' => {
           'type' => 'SP.Folder'
         },
-        'ServerRelativeUrl' => "#{path}/#{name}"
+        'ServerRelativeUrl' => "#{path}/#{sanitized_name}"
       }
       easy.http_request(url, :post, body: payload.to_json)
       easy.perform

--- a/spec/lib/sharepoint/client_methods_spec.rb
+++ b/spec/lib/sharepoint/client_methods_spec.rb
@@ -276,6 +276,10 @@ describe Sharepoint::Client do
   end
 
   describe '#create_folder' do
+    it 'does nothing if the folder name is nil' do
+      expect(Ethon::Easy).to_not receive(:new)
+      expect(client.create_folder(nil, 'bar')).to eq(nil)
+    end
     specify do
       mock_responses('request_digest.json')
       expect(client.create_folder('foo', 'bar')).to eq(200)


### PR DESCRIPTION
The sanitized name wasn't used, and triggered an exception when it was nil