### PR TITLE
Add URI escape / unescape tests

### DIFF
--- a/spec/lib/sharepoint/client_spec.rb
+++ b/spec/lib/sharepoint/client_spec.rb
@@ -131,4 +131,21 @@ describe Sharepoint::Client do
     end
   end
 
+  {
+    '[]'             => '%5B%5D',
+    "https://example.org/sites/Method('/file+name .pdf')" => "https://example.org/sites/Method('/file+name%20.pdf')"
+  }.each do |input, output|
+    describe '#uri_escape' do
+      specify do
+        expect(described_class.new(config).send :uri_escape, input).to eq(output)
+      end
+    end
+
+    describe '#uri_unescape' do
+      specify do
+        expect(described_class.new(config).send :uri_unescape, output).to eq(input)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Ruby does not implement an RFC 3986 compatible URI parser. The default
parser has been proved good enough for this use case.

An alternative approach would be to switch to a third-party RFC 3986
implementation, like the one provided by [addressable](https://github.com/sporkmonger/addressable)

The new specs test that square brackets are correctly escaped and
unescaped.