### PR TITLE
Refactor check and raise failure

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -52,7 +52,7 @@ Metrics/AbcSize:
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 514
+  Max: 513
 
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
@@ -66,11 +66,6 @@ Naming/MethodParameterName:
 
 # Configuration parameters: MinSize.
 Performance/CollectionLiteralInLoop:
-  Exclude:
-    - 'lib/sharepoint/client.rb'
-
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Performance/RangeInclude:
   Exclude:
     - 'lib/sharepoint/client.rb'
 
@@ -136,17 +131,6 @@ Style/FrozenStringLiteralComment:
     - 'lib/sharepoint/client.rb'
     - 'lib/sharepoint/errors.rb'
     - 'lib/sharepoint/spec_helpers.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: MinBodyLength, AllowConsecutiveConditionals.
-Style/GuardClause:
-  Exclude:
-    - 'lib/sharepoint/client.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-Style/IfUnlessModifier:
-  Exclude:
-    - 'lib/sharepoint/client.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/MapIntoArray:

--- a/lib/sharepoint/client.rb
+++ b/lib/sharepoint/client.rb
@@ -533,9 +533,9 @@ module Sharepoint
     end
 
     def check_and_raise_failure(ethon)
-      unless (200..299).include? ethon.response_code
-        raise "Request failed, received #{ethon.response_code}:\n#{ethon.url}\n#{ethon.response_body}"
-      end
+      return if (200..299).cover? ethon.response_code
+
+      raise "Request failed, received #{ethon.response_code}:\n#{ethon.url}\n#{ethon.response_body}"
     end
 
     def prepare_metadata(metadata, type)

--- a/spec/lib/sharepoint/client_methods_spec.rb
+++ b/spec/lib/sharepoint/client_methods_spec.rb
@@ -253,7 +253,7 @@ describe Sharepoint::Client do
   end
 
   describe '#search' do
-    subject { client.search(options) }
+    subject(:search) { client.search(options) }
 
     before { mock_responses('search_modified_documents.json') }
 
@@ -267,6 +267,18 @@ describe Sharepoint::Client do
     end
 
     it { is_expected.not_to be_empty }
+
+    context 'when request fails' do
+      before do
+        allow_any_instance_of(Ethon::Easy)
+          .to receive(:response_code)
+          .and_return(401)
+      end
+
+      it 'raises an error' do
+        expect { search }.to raise_error(/\ARequest failed, received 401.+/)
+      end
+    end
   end
 
   describe '#download' do


### PR DESCRIPTION
- Use `cover?` which is much faster than `include?`
- Use a guard clause to improve readability
- Add a spec

```
Comparison (IPS):
              cover?:  4483987.3 i/s
            include?:  2890227.4 i/s - 1.55x  (± 0.00) slower
```

---

Coverage increased `331 / 405 LOC (81.73%)`