### PR TITLE
Do not require spec helpers in production code

### DIFF
--- a/lib/sharepoint.rb
+++ b/lib/sharepoint.rb
@@ -1,3 +1,2 @@
 require 'sharepoint/errors'
 require 'sharepoint/client'
-require 'sharepoint/spec_helpers'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ SPEC_BASE = Pathname.new(__FILE__).realpath.parent
 
 $LOAD_PATH << ("#{SPEC_BASE.parent}lib")
 require 'sharepoint'
+require 'sharepoint/spec_helpers'
 
 def fixture(name)
   "#{SPEC_BASE}fixtures#{name}"


### PR DESCRIPTION
The intention of the current implementation, according to #2, is to make spec helpers available to gem users.

In this case, helpers should stay in lib, but they should not be required by production code and rather loaded in spec_helper (where appropriate, since the host application can use minitest)

Close #27