### PR TITLE
Add `URI_PARSER` for RFC2396 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ Gemfile.lock
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 .env
+
+.byebug_history

--- a/lib/sharepoint/client.rb
+++ b/lib/sharepoint/client.rb
@@ -21,6 +21,14 @@ module Sharepoint
     DEFAULT_NTLM_ETHON_OPTIONS = { httpauth: :ntlm, followlocation: 1, maxredirs: 5 }.freeze
     VALID_NTLM_CONFIG_OPTIONS = %i[username password].freeze
 
+    URI_PARSER =
+      if defined?(URI::RFC2396_PARSER)
+        URI::RFC2396_PARSER
+      else
+        URI::DEFAULT_PARSER
+      end
+    private_constant :URI_PARSER
+
     def authenticating_with_token
       generate_new_token
       yield
@@ -701,11 +709,11 @@ module Sharepoint
 
     # Waiting for RFC 3986 to be implemented, we need to escape square brackets
     def uri_escape(uri)
-      URI::DEFAULT_PARSER.escape(uri).gsub('[', '%5B').gsub(']', '%5D')
+      URI_PARSER.escape(uri).gsub('[', '%5B').gsub(']', '%5D')
     end
 
     def uri_unescape(uri)
-      URI::DEFAULT_PARSER.unescape(uri.gsub('%5B', '[').gsub('%5D', ']'))
+      URI_PARSER.unescape(uri.gsub('%5B', '[').gsub('%5D', ']'))
     end
 
     # TODO: Try to remove `eval` from this method. Otherwise, fix offenses


### PR DESCRIPTION
This commit introduces a new constant `URI_PARSER` to handle
URI parsing in a way that's compatible with both newer and older
versions of Ruby's URI library. It checks for the presence of
`URI::RFC2396_PARSER` and falls back to `URI::DEFAULT_PARSER` if
not available, ensuring consistent behavior across different Ruby
versions.

Close #53

Ref: ruby/uri#114