### PR TITLE
Add collaboration support for document sharing and permission management

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,9 +34,17 @@ Lint/UselessAssignment:
 Metrics/AbcSize:
   Max: 42
 
+# Configuration parameters: CountKeywordArgs, Max.
+Metrics/CyclomaticComplexity:
+  Max: 13
+
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
   Max: 31
+
+# Configuration parameters: Max.
+Metrics/PerceivedComplexity:
+  Max: 14
 
 # Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
 # AllowedNames: as, at, by, cc, db, id, if, in, io, ip, of, on, os, pp, to
@@ -54,9 +62,27 @@ Performance/UnfreezeString:
   Exclude:
     - 'lib/sharepoint/client.rb'
 
+# Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
+Naming/VariableNumber:
+  Exclude:
+    - 'spec/lib/sharepoint/client_collaboration_spec.rb'
+
 RSpec/AnyInstance:
   Exclude:
     - 'spec/lib/sharepoint/client_methods_spec.rb'
+    - 'spec/lib/sharepoint/client_collaboration_spec.rb'
+
+RSpec/DescribeMethod:
+  Exclude:
+    - 'spec/lib/sharepoint/client_collaboration_spec.rb'
+
+RSpec/IndexedLet:
+  Exclude:
+    - 'spec/lib/sharepoint/client_collaboration_spec.rb'
+
+RSpec/SpecFilePathFormat:
+  Exclude:
+    - 'spec/lib/sharepoint/client_collaboration_spec.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyle.

--- a/lib/sharepoint/client.rb
+++ b/lib/sharepoint/client.rb
@@ -496,7 +496,490 @@ module Sharepoint
       ethon_easy_requester
     end
 
+    # ========================================================================
+    # COLLABORATION METHODS
+    # ========================================================================
+    # The following methods support SharePoint collaboration workflows for
+    # document sharing, permission management, and web editing.
+    #
+    # Configuration requirements for collaboration features:
+    #   - site_path: The SharePoint site path (e.g., "/sites/my-site")
+    #   - base_folder: Base folder for collaboration documents
+    #   - base_uri: SharePoint base URI (e.g., "https://company.sharepoint.com")
+    # ========================================================================
+
+    FOLDER_SEPARATOR = '/'
+
+    OFFICE_TYPE_EXTENSIONS = {
+      '.doc' => 'w',   # Word
+      '.docx' => 'w',  # Word
+      '.xls' => 'x',   # Excel
+      '.xlsx' => 'x',  # Excel
+      '.ppt' => 'p',   # PowerPoint
+      '.pptx' => 'p'   # PowerPoint
+    }.freeze
+
+    # Uploads a document to SharePoint and returns its UniqueId
+    #
+    # @param filename [String] The name of the file
+    # @param file_content [String, IO] The file content
+    # @param folder_path [String] The relative folder path within base_folder
+    # @param metadata [Hash] Optional metadata for the document
+    # @return [Hash] { success: true, unique_id: String } or raises error
+    # @raise [UploadError] if upload fails
+    def collaboration_upload_document(filename, file_content, folder_path, metadata = {})
+      full_path = collaboration_build_full_path(folder_path)
+
+      collaboration_ensure_folder_exists(folder_path)
+
+      # Upload and capture the response with UniqueId
+      unique_id = collaboration_upload_and_get_unique_id(filename, file_content, full_path)
+
+      update_metadata(filename, metadata, full_path, collaboration_site_path) unless metadata.empty?
+
+      { success: true, unique_id: unique_id }
+    rescue StandardError => e
+      raise Sharepoint::Errors::UploadError.new("Failed to upload document: #{e.message}")
+    end
+
+    # Grants permissions to multiple users for a document
+    #
+    # @param filename [String] The name of the file
+    # @param folder_path [String] The relative folder path within base_folder
+    # @param user_emails [Array<String>] Array of user email addresses
+    # @param role_id [Integer] SharePoint role definition ID (e.g., 1073741827 for Contribute)
+    # @return [Boolean] true if successful
+    # @raise [PermissionError] if permission grant fails
+    def collaboration_grant_permissions(filename, folder_path, user_emails, role_id)
+      raise Sharepoint::Errors::PermissionError.new('user_emails cannot be nil') if user_emails.nil?
+      raise Sharepoint::Errors::PermissionError.new('user_emails must be an array') unless user_emails.is_a?(Array)
+      raise Sharepoint::Errors::PermissionError.new('user_emails cannot be empty') if user_emails.empty?
+      raise Sharepoint::Errors::PermissionError.new('role_id is required') if role_id.nil?
+
+      server_relative_url = collaboration_build_server_relative_url(filename, folder_path)
+
+      # First, ensure users are added to the site and break role inheritance
+      user_ids = user_emails.compact.map { |email| collaboration_ensure_user_and_get_id(email) }
+      collaboration_break_role_inheritance(server_relative_url)
+
+      # Grant permissions to each user
+      user_ids.each do |user_id|
+        collaboration_grant_user_permission(server_relative_url, user_id, role_id)
+      end
+
+      true
+    rescue Sharepoint::Errors::PermissionError
+      raise
+    rescue StandardError => e
+      raise Sharepoint::Errors::PermissionError.new("Failed to grant permissions: #{e.message}\n#{e.backtrace.first(5).join("\n")}")
+    end
+
+    # Revokes a single user's permission from a document
+    #
+    # @param filename [String] The name of the file
+    # @param folder_path [String] The relative folder path within base_folder
+    # @param user_email [String] The user's email address
+    # @return [Boolean] true if successful
+    # @raise [PermissionError] if permission revocation fails
+    def collaboration_revoke_user_permission(filename, folder_path, user_email)
+      server_relative_url = collaboration_build_server_relative_url(filename, folder_path)
+      user_id = collaboration_get_user_id(user_email)
+
+      collaboration_revoke_permission(server_relative_url, user_id)
+
+      true
+    rescue StandardError => e
+      raise Sharepoint::Errors::PermissionError.new("Failed to revoke user permission: #{e.message}")
+    end
+
+    # Revokes all permissions from a document (resets to inherited permissions)
+    #
+    # @param filename [String] The name of the file
+    # @param folder_path [String] The relative folder path within base_folder
+    # @return [Boolean] true if successful
+    # @raise [PermissionError] if permission reset fails
+    def collaboration_revoke_all_permissions(filename, folder_path)
+      server_relative_url = collaboration_build_server_relative_url(filename, folder_path)
+
+      collaboration_reset_role_inheritance(server_relative_url)
+
+      true
+    rescue StandardError => e
+      raise Sharepoint::Errors::PermissionError.new("Failed to revoke all permissions: #{e.message}")
+    end
+
+    # Generates the web edit URL for a document
+    #
+    # @param filename [String] The name of the file
+    # @param folder_path [String] The relative folder path within base_folder
+    # @param unique_id [String] Optional UniqueId (GUID) of the file
+    # @return [String] The web edit URL
+    def collaboration_get_web_edit_url(filename, folder_path, unique_id = nil)
+      # Use provided unique_id if available, otherwise try to fetch it
+      file_unique_id = unique_id || begin
+        server_relative_url = collaboration_build_server_relative_url(filename, folder_path)
+        collaboration_get_file_unique_id(server_relative_url)
+      end
+
+      office_type = detect_office_type(filename)
+
+      if file_unique_id.present?
+        # Use Doc.aspx with GUID format for web editing (most reliable)
+        escaped_filename = CGI.escape(filename)
+        "#{collaboration_base_uri}/:#{office_type}:/r#{collaboration_site_path}/_layouts/15/Doc.aspx?sourcedoc=%7B#{file_unique_id.upcase}%7D&file=#{escaped_filename}&action=default&mobileredirect=true&DefaultItemOpen=1"
+      else
+        # Fallback: Link to the folder view where user can click the file
+        escaped_folder = CGI.escape(folder_path)
+        "#{collaboration_base_uri}#{collaboration_site_path}/#{collaboration_base_folder}/#{escaped_folder}"
+      end
+    end
+
+    # Detects the Office file type for SharePoint web URLs
+    #
+    # @param filename [String] The filename
+    # @return [String] The office type code (w, x, p, or d)
+    def detect_office_type(filename)
+      extension = File.extname(filename).downcase
+      OFFICE_TYPE_EXTENSIONS.fetch(extension, 'd')
+    end
+
+    # Gets the UniqueId (GUID) of a file
+    #
+    # @param server_relative_url [String] The server-relative URL of the file
+    # @return [String, nil] The file's UniqueId or nil if not found
+    def collaboration_get_file_unique_id(server_relative_url)
+      ethon = ethon_easy_requester
+      escaped_url = CGI.escape(server_relative_url)
+      ethon.url = "#{collaboration_base_uri}/_api/web/getfilebyserverrelativeurl('#{escaped_url}')?$select=UniqueId"
+      ethon.headers = { 'Accept' => 'application/json;odata=verbose' }
+
+      authenticating_with_token do
+        ethon.perform
+      end
+
+      if defined?(Rails) && Rails.logger
+        Rails.logger.info("SharePoint UniqueId API response code: #{ethon.response_code}")
+        Rails.logger.info("SharePoint UniqueId API URL: #{ethon.url}")
+      end
+
+      if ethon.response_code == 200
+        response = JSON.parse(ethon.response_body)
+        unique_id = response.dig('d', 'UniqueId')
+        Rails.logger.info("SharePoint UniqueId retrieved: #{unique_id}") if defined?(Rails) && Rails.logger
+        unique_id
+      else
+        Rails.logger.warn("SharePoint UniqueId API failed with code #{ethon.response_code}: #{ethon.response_body[0..500]}") if defined?(Rails) && Rails.logger
+        nil
+      end
+    rescue StandardError => e
+      if defined?(Rails) && Rails.logger
+        Rails.logger.error("Failed to get file UniqueId: #{e.message}")
+        Rails.logger.error(e.backtrace[0..5].join("\n"))
+      end
+      nil
+    end
+
+    # Downloads a document from SharePoint
+    #
+    # @param filename [String] The name of the file
+    # @param folder_path [String] The relative folder path within base_folder
+    # @return [String] The file content
+    # @raise [DownloadError] if download fails
+    def collaboration_download_document(filename, folder_path)
+      full_path = collaboration_build_full_path(folder_path)
+      # The download method expects the file_path without site_path, with leading slash
+      file_path = "/#{full_path}/#{filename}"
+
+      # Use the existing download method which handles authentication properly
+      result = download(file_path: file_path, site_path: collaboration_site_path)
+
+      # The download method returns a hash with :file_contents key
+      result.is_a?(Hash) ? result[:file_contents] : result
+    rescue StandardError => e
+      raise Sharepoint::Errors::DownloadError.new("Failed to download document: #{e.message}")
+    end
+
+    # Deletes a document from SharePoint
+    #
+    # @param filename [String] The name of the file
+    # @param folder_path [String] The relative folder path within base_folder
+    # @return [Boolean] true if successful
+    # @raise [DeleteError] if deletion fails
+    def collaboration_delete_document(filename, folder_path)
+      server_relative_url = collaboration_build_server_relative_url(filename, folder_path)
+
+      ethon = ethon_easy_json_requester
+      ethon.headers = with_bearer_authentication_header({
+                                                          'accept' => 'application/json;odata=verbose',
+                                                          'X-RequestDigest' => xrequest_digest(collaboration_site_path),
+                                                          'IF-MATCH' => '*',
+                                                          'X-HTTP-Method' => 'DELETE'
+                                                        })
+
+      authenticating_with_token do
+        ethon.http_request(
+          uri_escape("#{collaboration_base_uri}#{collaboration_site_path}/_api/web/GetFileByServerRelativeUrl('#{server_relative_url}')"),
+          :post,
+          body: ''
+        )
+        ethon.perform
+      end
+
+      raise Sharepoint::Errors::DeleteError.new("Failed to delete document: HTTP #{ethon.response_code}") unless ethon.response_code == 200
+
+      true
+    rescue Sharepoint::Errors::DeleteError
+      raise
+    rescue StandardError => e
+      raise Sharepoint::Errors::DeleteError.new("Failed to delete document: #{e.message}")
+    end
+
+    # Checks if a document exists in SharePoint (collaboration version)
+    #
+    # @param filename [String] The name of the file
+    # @param folder_path [String] The relative folder path within base_folder
+    # @return [Boolean] true if document exists
+    def collaboration_document_exists?(filename, folder_path)
+      server_relative_url = collaboration_build_server_relative_url(filename, folder_path)
+
+      ethon = ethon_easy_json_requester
+      ethon.url = uri_escape("#{collaboration_base_uri}#{collaboration_site_path}/_api/web/GetFileByServerRelativeUrl('#{server_relative_url}')")
+
+      authenticating_with_token do
+        ethon.perform
+      end
+
+      ethon.response_code == 200
+    rescue StandardError
+      false
+    end
+
+    # Deletes a folder and all its contents from SharePoint
+    #
+    # @param folder_path [String] The relative folder path within base_folder
+    # @return [Boolean] true if successful
+    # @raise [DeleteError] if deletion fails
+    def collaboration_delete_folder(folder_path)
+      full_path = collaboration_build_full_path(folder_path)
+      server_relative_url = "#{collaboration_site_path}/#{full_path}"
+
+      ethon = ethon_easy_json_requester
+      ethon.headers = with_bearer_authentication_header({
+                                                          'accept' => 'application/json;odata=verbose',
+                                                          'X-RequestDigest' => xrequest_digest(collaboration_site_path),
+                                                          'IF-MATCH' => '*',
+                                                          'X-HTTP-Method' => 'DELETE'
+                                                        })
+
+      authenticating_with_token do
+        ethon.http_request(
+          uri_escape("#{collaboration_base_uri}#{collaboration_site_path}/_api/web/GetFolderByServerRelativeUrl('#{server_relative_url}')"),
+          :post,
+          body: ''
+        )
+        ethon.perform
+      end
+
+      unless ethon.response_code == 200
+        raise Sharepoint::Errors::DeleteError.new(
+          "Failed to delete folder: HTTP #{ethon.response_code} - #{ethon.response_body}"
+        )
+      end
+
+      true
+    rescue Sharepoint::Errors::DeleteError
+      raise
+    rescue StandardError => e
+      raise Sharepoint::Errors::DeleteError.new("Failed to delete folder: #{e.message}")
+    end
+
     private
+
+    # Gets collaboration configuration values with fallback
+    def collaboration_site_path
+      @config.site_path || ''
+    end
+
+    def collaboration_base_folder
+      @config.base_folder || ''
+    end
+
+    def collaboration_base_uri
+      @config.base_uri || @config.uri
+    end
+
+    # Builds the full path within SharePoint
+    def collaboration_build_full_path(folder_path)
+      [collaboration_base_folder, folder_path].reject(&:empty?).join(FOLDER_SEPARATOR)
+    end
+
+    # Builds the server-relative URL for a document
+    def collaboration_build_server_relative_url(filename, folder_path)
+      full_path = collaboration_build_full_path(folder_path)
+      "#{collaboration_site_path}/#{full_path}/#{filename}"
+    end
+
+    # Ensures a folder exists, creating it if necessary
+    def collaboration_ensure_folder_exists(folder_path)
+      full_path = collaboration_build_full_path(folder_path)
+      return if folder_exists?(full_path, collaboration_site_path)
+
+      create_folder(folder_path, collaboration_base_folder, collaboration_site_path)
+    end
+
+    # Uploads a file and extracts UniqueId from response
+    def collaboration_upload_and_get_unique_id(filename, file_content, full_path)
+      sanitized_filename = sanitize_filename(filename)
+      url = computed_web_api_url(collaboration_site_path)
+      path = full_path[0].eql?('/') ? full_path[1..] : full_path
+      upload_url = uri_escape("#{url}GetFolderByServerRelativeUrl('#{path}')/Files/Add(url='#{sanitized_filename}',overwrite=true)")
+
+      ethon = ethon_easy_json_requester
+      ethon.headers = with_bearer_authentication_header({
+                                                          'accept' => 'application/json;odata=verbose',
+                                                          'X-RequestDigest' => xrequest_digest(collaboration_site_path)
+                                                        })
+      ethon.http_request(upload_url, :post, { body: file_content })
+
+      authenticating_with_token do
+        ethon.perform
+      end
+
+      check_and_raise_failure(ethon)
+
+      if ethon.response_code == 200
+        begin
+          response = JSON.parse(ethon.response_body)
+          unique_id = response.dig('d', 'UniqueId')
+          Rails.logger.info("SharePoint upload successful, UniqueId: #{unique_id}") if defined?(Rails) && Rails.logger
+          unique_id
+        rescue JSON::ParserError => e
+          Rails.logger.error("Failed to parse upload response: #{e.message}") if defined?(Rails) && Rails.logger
+          nil
+        end
+      else
+        Rails.logger.warn("SharePoint upload returned code #{ethon.response_code}") if defined?(Rails) && Rails.logger
+        nil
+      end
+    rescue StandardError => e
+      Rails.logger.error("Failed to get UniqueId from upload: #{e.message}") if defined?(Rails) && Rails.logger
+      nil
+    end
+
+    # Adds a user to the site and returns their ID
+    def collaboration_ensure_user_and_get_id(email)
+      payload = { 'logonName' => "i:0#.f|membership|#{email}" }
+
+      ethon = ethon_easy_json_requester
+      ethon.headers = with_bearer_authentication_header({
+                                                          'accept' => 'application/json;odata=verbose',
+                                                          'content-type' => 'application/json;odata=verbose',
+                                                          'X-RequestDigest' => xrequest_digest(collaboration_site_path)
+                                                        })
+
+      authenticating_with_token do
+        ethon.http_request(
+          uri_escape("#{collaboration_base_uri}#{collaboration_site_path}/_api/web/ensureuser"),
+          :post,
+          body: payload.to_json
+        )
+        ethon.perform
+      end
+
+      raise Sharepoint::Errors::PermissionError.new("Failed to ensure user #{email}: HTTP #{ethon.response_code}, Response: #{ethon.response_body}") unless ethon.response_code == 200
+
+      response = JSON.parse(ethon.response_body)
+      user_id = response.dig('d', 'Id')
+
+      raise Sharepoint::Errors::PermissionError.new("Failed to get user ID for #{email}") if user_id.nil?
+
+      user_id
+    end
+
+    # Gets a user ID from their email (assumes they're already in the site)
+    def collaboration_get_user_id(email)
+      collaboration_ensure_user_and_get_id(email)
+    end
+
+    # Breaks role inheritance for a document
+    def collaboration_break_role_inheritance(server_relative_url)
+      ethon = ethon_easy_json_requester
+      ethon.headers = with_bearer_authentication_header({
+                                                          'accept' => 'application/json;odata=verbose',
+                                                          'X-RequestDigest' => xrequest_digest(collaboration_site_path)
+                                                        })
+
+      authenticating_with_token do
+        ethon.http_request(
+          uri_escape(
+            "#{collaboration_base_uri}#{collaboration_site_path}/_api/web/GetFileByServerRelativeUrl('#{server_relative_url}')/ListItemAllFields/breakroleinheritance(copyRoleAssignments=false,clearSubscopes=true)"
+          ),
+          :post,
+          body: ''
+        )
+        ethon.perform
+      end
+    end
+
+    # Resets role inheritance for a document
+    def collaboration_reset_role_inheritance(server_relative_url)
+      ethon = ethon_easy_json_requester
+      ethon.headers = with_bearer_authentication_header({
+                                                          'accept' => 'application/json;odata=verbose',
+                                                          'X-RequestDigest' => xrequest_digest(collaboration_site_path)
+                                                        })
+
+      authenticating_with_token do
+        ethon.http_request(
+          uri_escape("#{collaboration_base_uri}#{collaboration_site_path}/_api/web/GetFileByServerRelativeUrl('#{server_relative_url}')/ListItemAllFields/resetroleinheritance"),
+          :post,
+          body: ''
+        )
+        ethon.perform
+      end
+    end
+
+    # Grants permission to a specific user
+    def collaboration_grant_user_permission(server_relative_url, user_id, role_id)
+      ethon = ethon_easy_json_requester
+      ethon.headers = with_bearer_authentication_header({
+                                                          'accept' => 'application/json;odata=verbose',
+                                                          'X-RequestDigest' => xrequest_digest(collaboration_site_path)
+                                                        })
+
+      authenticating_with_token do
+        ethon.http_request(
+          uri_escape(
+            "#{collaboration_base_uri}#{collaboration_site_path}/_api/web/GetFileByServerRelativeUrl('#{server_relative_url}')/ListItemAllFields/roleassignments/addroleassignment(principalid=#{user_id},roleDefId=#{role_id})"
+          ),
+          :post,
+          body: ''
+        )
+        ethon.perform
+      end
+    end
+
+    # Revokes permission from a specific user
+    def collaboration_revoke_permission(server_relative_url, user_id)
+      ethon = ethon_easy_json_requester
+      ethon.headers = with_bearer_authentication_header({
+                                                          'accept' => 'application/json;odata=verbose',
+                                                          'X-RequestDigest' => xrequest_digest(collaboration_site_path),
+                                                          'IF-MATCH' => '*',
+                                                          'X-HTTP-Method' => 'DELETE'
+                                                        })
+
+      authenticating_with_token do
+        ethon.http_request(
+          uri_escape(
+            "#{collaboration_base_uri}#{collaboration_site_path}/_api/web/GetFileByServerRelativeUrl('#{server_relative_url}')/ListItemAllFields/roleassignments/getbyprincipalid(#{user_id})"
+          ),
+          :post,
+          body: ''
+        )
+        ethon.perform
+      end
+    end
 
     def process_url(url, fields)
       easy = ethon_easy_json_requester

--- a/lib/sharepoint/errors.rb
+++ b/lib/sharepoint/errors.rb
@@ -39,5 +39,11 @@ module Sharepoint
         super(error_messages.join(','))
       end
     end
+
+    # Collaboration error classes
+    class UploadError < StandardError; end
+    class PermissionError < StandardError; end
+    class DownloadError < StandardError; end
+    class DeleteError < StandardError; end
   end
 end

--- a/lib/sharepoint/version.rb
+++ b/lib/sharepoint/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sharepoint
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/spec/lib/sharepoint/client_collaboration_spec.rb
+++ b/spec/lib/sharepoint/client_collaboration_spec.rb
@@ -1,0 +1,582 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sharepoint::Client, 'Collaboration Methods' do
+  before do
+    ENV['SP_URL'] = 'https://localhost:8888'
+    ENV['SP_AUTHENTICATION'] = 'token'
+    ENV['SP_CLIENT_ID'] = 'test_client_id'
+    ENV['SP_CLIENT_SECRET'] = 'test_client_secret'
+    ENV['SP_TENANT_ID'] = 'test_tenant_id'
+    ENV['SP_CERT_NAME'] = 'test_cert'
+    ENV['SP_AUTH_SCOPE'] = 'https://test.sharepoint.com/.default'
+
+    mock_requests
+    mock_token_responses
+
+    # Mock xrequest_digest calls for POST requests
+    allow_any_instance_of(described_class).to receive(:xrequest_digest).and_return('mock_digest_value')
+  end
+
+  let(:config) do
+    sp_config(authentication: 'token').merge({
+                                               site_path: '/sites/test-site',
+                                               base_folder: 'Shared Documents/Collaboration',
+                                               base_uri: 'https://company.sharepoint.com'
+                                             })
+  end
+
+  let(:client) { described_class.new(config) }
+  let(:filename) { 'test-document.docx' }
+  let(:folder_path) { 'project-123' }
+  let(:file_content) { 'test file content' }
+
+  describe '#collaboration_upload_document' do
+    subject(:upload_document) { client.collaboration_upload_document(filename, file_content, folder_path) }
+
+    let(:unique_id) { '12345678-1234-1234-1234-123456789abc' }
+    let(:upload_response) { { 'd' => { 'UniqueId' => unique_id } }.to_json }
+
+    before do
+      allow(client).to receive(:update_metadata)
+
+      # Mock collaboration_upload_and_get_unique_id to return the unique_id
+      allow(client).to receive_messages(folder_exists?: true, collaboration_upload_and_get_unique_id: unique_id)
+    end
+
+    it 'returns success with unique_id' do
+      expect(upload_document).to eq({ success: true, unique_id: unique_id })
+    end
+
+    context 'with metadata' do
+      subject(:upload_document) do
+        client.collaboration_upload_document(filename, file_content, folder_path, { 'Title' => 'Test Document' })
+      end
+
+      it 'updates metadata' do
+        upload_document
+        expect(client).to have_received(:update_metadata).with(
+          filename,
+          { 'Title' => 'Test Document' },
+          'Shared Documents/Collaboration/project-123',
+          '/sites/test-site'
+        )
+      end
+    end
+
+    context 'when folder does not exist' do
+      before do
+        allow(client).to receive(:folder_exists?).and_return(false)
+        allow(client).to receive(:create_folder)
+      end
+
+      it 'creates the folder' do
+        upload_document
+        expect(client).to have_received(:create_folder).with(
+          folder_path,
+          'Shared Documents/Collaboration',
+          '/sites/test-site'
+        )
+      end
+    end
+
+    context 'when upload fails' do
+      before do
+        allow(client).to receive(:collaboration_upload_and_get_unique_id).and_raise(StandardError, 'Upload failed')
+      end
+
+      it 'raises UploadError' do
+        expect { upload_document }.to raise_error(Sharepoint::Errors::UploadError, /Failed to upload document/)
+      end
+    end
+  end
+
+  describe '#collaboration_grant_permissions' do
+    subject(:grant_permissions) do
+      client.collaboration_grant_permissions(filename, folder_path, user_emails, role_id)
+    end
+
+    let(:user_emails) { ['user1@example.com', 'user2@example.com'] }
+    let(:role_id) { 1_073_741_827 } # Contribute role
+    let(:user_id_1) { 123 }
+    let(:user_id_2) { 456 }
+
+    before do
+      allow_any_instance_of(Ethon::Easy).to receive(:response_code).and_return(200)
+      allow_any_instance_of(Ethon::Easy).to receive(:response_body).and_return(
+        { 'd' => { 'Id' => user_id_1 } }.to_json
+      )
+    end
+
+    it 'returns true on success' do
+      expect(grant_permissions).to be true
+    end
+
+    context 'with nil user_emails' do
+      let(:user_emails) { nil }
+
+      it 'raises PermissionError' do
+        expect { grant_permissions }.to raise_error(
+          Sharepoint::Errors::PermissionError,
+          'user_emails cannot be nil'
+        )
+      end
+    end
+
+    context 'with non-array user_emails' do
+      let(:user_emails) { 'user@example.com' }
+
+      it 'raises PermissionError' do
+        expect { grant_permissions }.to raise_error(
+          Sharepoint::Errors::PermissionError,
+          'user_emails must be an array'
+        )
+      end
+    end
+
+    context 'with empty user_emails' do
+      let(:user_emails) { [] }
+
+      it 'raises PermissionError' do
+        expect { grant_permissions }.to raise_error(
+          Sharepoint::Errors::PermissionError,
+          'user_emails cannot be empty'
+        )
+      end
+    end
+
+    context 'with nil role_id' do
+      let(:role_id) { nil }
+
+      it 'raises PermissionError' do
+        expect { grant_permissions }.to raise_error(
+          Sharepoint::Errors::PermissionError,
+          'role_id is required'
+        )
+      end
+    end
+  end
+
+  describe '#collaboration_revoke_user_permission' do
+    subject(:revoke_user_permission) do
+      client.collaboration_revoke_user_permission(filename, folder_path, user_email)
+    end
+
+    let(:user_email) { 'user@example.com' }
+    let(:user_id) { 123 }
+
+    before do
+      allow_any_instance_of(Ethon::Easy).to receive(:response_code).and_return(200)
+      allow_any_instance_of(Ethon::Easy).to receive(:response_body).and_return(
+        { 'd' => { 'Id' => user_id } }.to_json
+      )
+    end
+
+    it 'returns true on success' do
+      expect(revoke_user_permission).to be true
+    end
+
+    context 'when revocation fails' do
+      before do
+        allow_any_instance_of(Ethon::Easy).to receive(:response_code).and_return(500)
+      end
+
+      it 'raises PermissionError' do
+        expect { revoke_user_permission }.to raise_error(Sharepoint::Errors::PermissionError)
+      end
+    end
+  end
+
+  describe '#collaboration_revoke_all_permissions' do
+    subject(:revoke_all_permissions) do
+      client.collaboration_revoke_all_permissions(filename, folder_path)
+    end
+
+    before do
+      allow_any_instance_of(Ethon::Easy).to receive(:response_code).and_return(200)
+    end
+
+    it 'returns true on success' do
+      expect(revoke_all_permissions).to be true
+    end
+
+    context 'when reset fails' do
+      before do
+        allow(client).to receive(:collaboration_reset_role_inheritance).and_raise(StandardError, 'Reset failed')
+      end
+
+      it 'raises PermissionError' do
+        expect { revoke_all_permissions }.to raise_error(
+          Sharepoint::Errors::PermissionError,
+          /Failed to revoke all permissions/
+        )
+      end
+    end
+  end
+
+  describe '#collaboration_get_web_edit_url' do
+    subject(:get_web_edit_url) do
+      client.collaboration_get_web_edit_url(filename, folder_path, unique_id)
+    end
+
+    let(:unique_id) { '12345678-1234-1234-1234-123456789abc' }
+
+    context 'with unique_id provided' do
+      it 'returns a web edit URL with GUID format' do
+        expect(get_web_edit_url).to include('/_layouts/15/Doc.aspx')
+        expect(get_web_edit_url).to include(unique_id.upcase)
+        expect(get_web_edit_url).to include('test-document.docx')
+      end
+    end
+
+    context 'without unique_id' do
+      let(:unique_id) { nil }
+
+      before do
+        allow(client).to receive(:collaboration_get_file_unique_id).and_return(nil)
+      end
+
+      it 'returns a fallback folder URL' do
+        expect(get_web_edit_url).to include('Shared')
+        expect(get_web_edit_url).to include('Documents')
+        expect(get_web_edit_url).to include('Collaboration')
+        expect(get_web_edit_url).to include('project-123')
+      end
+    end
+
+    context 'with empty unique_id' do
+      let(:unique_id) { '' }
+
+      it 'returns a fallback folder URL' do
+        expect(get_web_edit_url).to include('Shared')
+        expect(get_web_edit_url).to include('Documents')
+        expect(get_web_edit_url).to include('Collaboration')
+        expect(get_web_edit_url).to include('project-123')
+      end
+    end
+  end
+
+  describe '#detect_office_type' do
+    {
+      'document.doc' => 'w',
+      'document.docx' => 'w',
+      'spreadsheet.xls' => 'x',
+      'spreadsheet.xlsx' => 'x',
+      'presentation.ppt' => 'p',
+      'presentation.pptx' => 'p',
+      'other.pdf' => 'd'
+    }.each do |filename, expected_type|
+      it "detects #{expected_type} for #{filename}" do
+        expect(client.detect_office_type(filename)).to eq(expected_type)
+      end
+    end
+  end
+
+  describe '#collaboration_get_file_unique_id' do
+    subject(:get_file_unique_id) { client.collaboration_get_file_unique_id(server_relative_url) }
+
+    let(:server_relative_url) { '/sites/test-site/Shared Documents/file.docx' }
+    let(:unique_id) { '12345678-1234-1234-1234-123456789abc' }
+
+    before do
+      allow_any_instance_of(Ethon::Easy).to receive(:response_code).and_return(200)
+      allow_any_instance_of(Ethon::Easy).to receive(:response_body).and_return(
+        { 'd' => { 'UniqueId' => unique_id } }.to_json
+      )
+    end
+
+    it 'returns the unique_id' do
+      expect(get_file_unique_id).to eq(unique_id)
+    end
+
+    context 'when file not found' do
+      before do
+        allow_any_instance_of(Ethon::Easy).to receive(:response_code).and_return(404)
+      end
+
+      it 'returns nil' do
+        expect(get_file_unique_id).to be_nil
+      end
+    end
+
+    context 'when API call fails' do
+      before do
+        allow_any_instance_of(Ethon::Easy).to receive(:perform).and_raise(StandardError, 'Network error')
+      end
+
+      it 'returns nil' do
+        expect(get_file_unique_id).to be_nil
+      end
+    end
+  end
+
+  describe '#collaboration_download_document' do
+    subject(:download_document) { client.collaboration_download_document(filename, folder_path) }
+
+    let(:file_contents) { 'downloaded file content' }
+
+    before do
+      allow(client).to receive(:download).and_return({ file_contents: file_contents })
+    end
+
+    it 'returns file contents' do
+      expect(download_document).to eq(file_contents)
+    end
+
+    context 'when download method returns string directly' do
+      before do
+        allow(client).to receive(:download).and_return(file_contents)
+      end
+
+      it 'returns the string' do
+        expect(download_document).to eq(file_contents)
+      end
+    end
+
+    context 'when download fails' do
+      before do
+        allow(client).to receive(:download).and_raise(StandardError, 'Download failed')
+      end
+
+      it 'raises DownloadError' do
+        expect { download_document }.to raise_error(
+          Sharepoint::Errors::DownloadError,
+          /Failed to download document/
+        )
+      end
+    end
+  end
+
+  describe '#collaboration_delete_document' do
+    subject(:delete_document) { client.collaboration_delete_document(filename, folder_path) }
+
+    before do
+      allow_any_instance_of(Ethon::Easy).to receive(:response_code).and_return(200)
+    end
+
+    it 'returns true on success' do
+      expect(delete_document).to be true
+    end
+
+    context 'when deletion fails' do
+      before do
+        allow_any_instance_of(Ethon::Easy).to receive(:response_code).and_return(404)
+      end
+
+      it 'raises DeleteError' do
+        expect { delete_document }.to raise_error(
+          Sharepoint::Errors::DeleteError,
+          /Failed to delete document: HTTP 404/
+        )
+      end
+    end
+
+    context 'when API call raises error' do
+      before do
+        allow_any_instance_of(Ethon::Easy).to receive(:perform).and_raise(StandardError, 'Network error')
+      end
+
+      it 'raises DeleteError' do
+        expect { delete_document }.to raise_error(
+          Sharepoint::Errors::DeleteError,
+          /Failed to delete document/
+        )
+      end
+    end
+  end
+
+  describe '#collaboration_delete_folder' do
+    subject(:delete_folder) { client.collaboration_delete_folder(folder_path) }
+
+    before do
+      allow_any_instance_of(Ethon::Easy).to receive(:response_code).and_return(200)
+    end
+
+    it 'returns true on success' do
+      expect(delete_folder).to be true
+    end
+
+    context 'when deletion fails' do
+      before do
+        allow_any_instance_of(Ethon::Easy).to receive(:response_code).and_return(404)
+        allow_any_instance_of(Ethon::Easy).to receive(:response_body).and_return('Not Found')
+      end
+
+      it 'raises DeleteError' do
+        expect { delete_folder }.to raise_error(
+          Sharepoint::Errors::DeleteError,
+          /Failed to delete folder: HTTP 404/
+        )
+      end
+    end
+
+    context 'when API call raises error' do
+      before do
+        allow_any_instance_of(Ethon::Easy).to receive(:perform).and_raise(StandardError, 'Network error')
+      end
+
+      it 'raises DeleteError' do
+        expect { delete_folder }.to raise_error(
+          Sharepoint::Errors::DeleteError,
+          /Failed to delete folder/
+        )
+      end
+    end
+  end
+
+  describe '#collaboration_document_exists?' do
+    subject(:collaboration_document_exists?) do
+      client.collaboration_document_exists?(filename, folder_path)
+    end
+
+    before do
+      allow_any_instance_of(Ethon::Easy).to receive(:response_code).and_return(200)
+    end
+
+    it 'returns true when document exists' do
+      expect(collaboration_document_exists?).to be true
+    end
+
+    context 'when document does not exist' do
+      before do
+        allow_any_instance_of(Ethon::Easy).to receive(:response_code).and_return(404)
+      end
+
+      it 'returns false' do
+        expect(collaboration_document_exists?).to be false
+      end
+    end
+
+    context 'when API call raises error' do
+      before do
+        allow_any_instance_of(Ethon::Easy).to receive(:perform).and_raise(StandardError, 'Network error')
+      end
+
+      it 'returns false' do
+        expect(collaboration_document_exists?).to be false
+      end
+    end
+  end
+
+  describe 'private helper methods' do
+    describe '#collaboration_site_path' do
+      it 'returns site_path from config' do
+        expect(client.send(:collaboration_site_path)).to eq('/sites/test-site')
+      end
+
+      context 'when site_path is not configured' do
+        let(:config) { sp_config(authentication: 'token').merge({ base_folder: 'Shared Documents' }) }
+
+        it 'returns empty string' do
+          expect(client.send(:collaboration_site_path)).to eq('')
+        end
+      end
+    end
+
+    describe '#collaboration_base_folder' do
+      it 'returns base_folder from config' do
+        expect(client.send(:collaboration_base_folder)).to eq('Shared Documents/Collaboration')
+      end
+
+      context 'when base_folder is not configured' do
+        let(:config) { sp_config(authentication: 'token').merge({ site_path: '/sites/test' }) }
+
+        it 'returns empty string' do
+          expect(client.send(:collaboration_base_folder)).to eq('')
+        end
+      end
+    end
+
+    describe '#collaboration_base_uri' do
+      it 'returns base_uri from config' do
+        expect(client.send(:collaboration_base_uri)).to eq('https://company.sharepoint.com')
+      end
+
+      context 'when base_uri is not configured' do
+        let(:config) do
+          sp_config(authentication: 'token').merge({
+                                                     uri: 'https://default-uri.sharepoint.com',
+                                                     site_path: '/sites/test',
+                                                     base_folder: 'Shared'
+                                                   })
+        end
+
+        it 'falls back to uri from config' do
+          expect(client.send(:collaboration_base_uri)).to eq('https://default-uri.sharepoint.com')
+        end
+      end
+    end
+
+    describe '#collaboration_build_full_path' do
+      it 'combines base_folder and folder_path' do
+        full_path = client.send(:collaboration_build_full_path, 'project-123')
+        expect(full_path).to eq('Shared Documents/Collaboration/project-123')
+      end
+
+      context 'when base_folder is empty' do
+        let(:config) { sp_config(authentication: 'token').merge({ site_path: '/sites/test' }) }
+
+        it 'returns only folder_path' do
+          full_path = client.send(:collaboration_build_full_path, 'project-123')
+          expect(full_path).to eq('project-123')
+        end
+      end
+
+      context 'when folder_path is empty' do
+        it 'returns only base_folder' do
+          full_path = client.send(:collaboration_build_full_path, '')
+          expect(full_path).to eq('Shared Documents/Collaboration')
+        end
+      end
+    end
+
+    describe '#collaboration_build_server_relative_url' do
+      it 'builds complete server-relative URL' do
+        url = client.send(:collaboration_build_server_relative_url, filename, folder_path)
+        expect(url).to eq('/sites/test-site/Shared Documents/Collaboration/project-123/test-document.docx')
+      end
+    end
+  end
+
+  describe 'configuration validation' do
+    context 'with missing site_path' do
+      let(:config) do
+        sp_config(authentication: 'token').merge({
+                                                   base_folder: 'Shared Documents',
+                                                   base_uri: 'https://company.sharepoint.com'
+                                                 })
+      end
+
+      it 'uses empty string as default' do
+        expect(client.send(:collaboration_site_path)).to eq('')
+      end
+    end
+
+    context 'with missing base_folder' do
+      let(:config) do
+        sp_config(authentication: 'token').merge({
+                                                   site_path: '/sites/test-site',
+                                                   base_uri: 'https://company.sharepoint.com'
+                                                 })
+      end
+
+      it 'uses empty string as default' do
+        expect(client.send(:collaboration_base_folder)).to eq('')
+      end
+    end
+
+    context 'with missing base_uri' do
+      let(:config) do
+        sp_config(authentication: 'token').merge({
+                                                   site_path: '/sites/test-site',
+                                                   base_folder: 'Shared Documents'
+                                                 })
+      end
+
+      it 'falls back to uri' do
+        expect(client.send(:collaboration_base_uri)).to eq(ENV.fetch('SP_URL', nil))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add collaboration support for document sharing and permission management

- Add collaboration methods to Sharepoint::Client:
  - collaboration_upload_document: Upload with UniqueId capture
  - collaboration_grant_permissions: Grant permissions to multiple users
  - collaboration_revoke_user_permission: Revoke single user permission
  - collaboration_revoke_all_permissions: Reset to inherited permissions
  - collaboration_get_web_edit_url: Generate SharePoint web editor URLs
  - collaboration_download_document: Download with proper content extraction
  - collaboration_delete_document: Delete documents from SharePoint
  - collaboration_delete_folder: Delete folders and their contents
  - collaboration_get_file_unique_id: Get file GUID
  - collaboration_document_exists?: Check if document exists
  - detect_office_type: Detect file type for web URLs (no prefix)

- Add collaboration error classes:
  - UploadError, PermissionError, DownloadError, DeleteError

- Configuration support for collaboration:
  - site_path: SharePoint site path
  - base_folder: Base collaboration folder
  - base_uri: SharePoint base URI